### PR TITLE
feat: add nix-index-database

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -89,6 +89,26 @@
         "type": "github"
       }
     },
+    "nix-index-database": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1681392449,
+        "narHash": "sha256-Ld8n4QiqfDegqnRBq5LZ+kryENyEGNif/LBjwhqXopc=",
+        "owner": "Mic92",
+        "repo": "nix-index-database",
+        "rev": "c93f2e0bfe779601be514e1bca3b02443d4ce46b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Mic92",
+        "repo": "nix-index-database",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1675512093,
@@ -209,6 +229,7 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "home-manager": "home-manager",
+        "nix-index-database": "nix-index-database",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "pre-commit-hooks": "pre-commit-hooks",

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,8 @@
     pre-commit-hooks.url = "github:cachix/pre-commit-hooks.nix";
     flake-utils.url = "github:numtide/flake-utils";
 
+    nix-index-database.url = "github:Mic92/nix-index-database";
+    nix-index-database.inputs.nixpkgs.follows = "nixpkgs";
     sops.url = "github:Mic92/sops-nix";
   };
 
@@ -19,6 +21,7 @@
     home-manager,
     pre-commit-hooks,
     flake-utils,
+    nix-index-database,
     sops,
     ...
   }: let
@@ -45,6 +48,7 @@
               useUserPackages = true;
               backupFileExtension = "backup";
               sharedModules = [
+                nix-index-database.hmModules.nix-index
                 sops.homeManagerModules.sops
               ];
               extraSpecialArgs = {


### PR DESCRIPTION
Avoids having to run `nix-index` manually, also allows you to get rid of channels entirely because of the precompiled db.

https://github.com/Mic92/nix-index-database